### PR TITLE
add primitive autoupdate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These playbooks only work with [systemd](https://systemd.io/)-based hosts, which
 ### Mandatory setup
 1. Assuming you're using Ubuntu (WSL default), install Python, Ansible, and Docker using `sudo apt install -y python3 ansible docker.io`
 2. On all `tf2` hosts (dedicated servers):
-- 1. `sudo apt install -y docker.io` - Install Docker.
+- 1. `sudo apt install -y docker.io docker-compose-v2` - Install Docker and Docker-Compose.
 - 2. `sudo useradd -UmG docker tf2server` - Create the `tf2server` user with the `docker` role.
 - 3. `sudo loginctl enable-linger tf2server` - Enable systemd service lingering.
 

--- a/roles/deploy/files/updater.sh
+++ b/roles/deploy/files/updater.sh
@@ -12,13 +12,14 @@ get_networks() {
 
 get_servers_for_network() {
     SERVERS=()
-    for server in /home/tf2server/build/servers/$0/*; do
+    for server in /home/tf2server/build/servers/$1/*; do
         server=${server##*/}
         SERVERS+=( $server )
     done
 }
 
 main() {
+    echo ""
     echo "[$(date +'%D %H:%M:%S')] Checking..."
 
     CURRENT=$(cat current_tf2_buildid)
@@ -46,18 +47,20 @@ main() {
 
             for server in ${SERVERS[@]} ; do
                 echo "[$(date +'%D %H:%M:%S')] Rebuilding $network/$server..."
-                docker buildx build -t srcds-$network-$server:latest /home/tf2server/build/servers/$network/$server
+                cd /home/tf2server/build/servers/$network/$server
+                docker buildx build -t srcds-$network-$server:latest .
+                cd /home/tf2server
             done
 
             echo "[$(date +'%D %H:%M:%S')] Docker recomposing $network..."
-            docker-compose -f /home/tf2server/docker-compose_$network.yml up -d
+            docker compose -f /home/tf2server/docker-compose_$network.yml up -d
         done
 
-        echo $LATEST > current
+        echo $LATEST > current_tf2_buildid
         exit 0
 
     else
-        echo "[$(date +'%D %H:%M:%S')] Current is latest"
+        echo "[$(date +'%D %H:%M:%S')] Current is latest, nothing to do"
         exit 0
 
     fi

--- a/roles/deploy/files/updater.sh
+++ b/roles/deploy/files/updater.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# ansible-tf2network: server autoupdater
+
+get_networks() {
+    NETWORKS=()
+    for network in /home/tf2server/build/servers/*; do
+        network=${network##*/}
+        NETWORKS+=( $network )
+    done
+}
+
+get_servers_for_network() {
+    SERVERS=()
+    for server in /home/tf2server/build/servers/$0/*; do
+        server=${server##*/}
+        SERVERS+=( $server )
+    done
+}
+
+main() {
+    echo "[$(date +'%D %H:%M:%S')] Checking..."
+
+    CURRENT=$(cat current_tf2_buildid)
+    LATEST=$(docker run --quiet --pull always --rm --entrypoint=/bin/bash cm2network/steamcmd -c './steamcmd.sh +login anonymous +app_info_update 232250 +app_info_print 232250 +quit' | perl -n -e'/"buildid"\s+"([    0-9]+)"/ && print "$1\n"' | head -n1)
+
+    echo "[$(date +'%D %H:%M:%S')] Current: $CURRENT; Latest: $LATEST"
+
+    if [ ! -f current_tf2_buildid ]; then
+        echo "[$(date +'%D %H:%M:%S')] No current version saved, saving latest as current and doing nothing!"
+        echo $LATEST > current_tf2_buildid
+        exit 0
+
+    elif [[ "$CURRENT" -ne "$LATEST" ]]; then
+        # rebuild (update) the base image
+        echo "[$(date +'%D %H:%M:%S')] Updating base image..."
+        docker buildx build -t jackavery/base-tf2server:latest /home/tf2server/build/base
+
+        get_networks
+
+        # rebuild servers
+        for network in ${NETWORKS[@]} ; do
+            echo "[$(date +'%D %H:%M:%S')] Processing $network..."
+
+            get_servers_for_network $network
+
+            for server in ${SERVERS[@]} ; do
+                echo "[$(date +'%D %H:%M:%S')] Rebuilding $network/$server..."
+                docker buildx build -t srcds-$network-$server:latest /home/tf2server/build/servers/$network/$server
+            done
+
+            echo "[$(date +'%D %H:%M:%S')] Docker recomposing $network..."
+            docker-compose -f /home/tf2server/docker-compose_$network.yml up -d
+        done
+
+        echo $LATEST > current
+        exit 0
+
+    else
+        echo "[$(date +'%D %H:%M:%S')] Current is latest"
+        exit 0
+
+    fi
+}
+
+main $@

--- a/roles/deploy/files/updater.sh
+++ b/roles/deploy/files/updater.sh
@@ -20,6 +20,13 @@ get_servers_for_network() {
 
 main() {
     echo ""
+
+    if [ -f updater-active.lock ]; then
+        echo "[$(date +'%D %H:%M:%S')] A job is already active. Cancelling..."
+        exit 0
+    fi
+    touch updater-active.lock
+
     echo "[$(date +'%D %H:%M:%S')] Checking..."
 
     CURRENT=$(cat current_tf2_buildid)
@@ -30,6 +37,8 @@ main() {
     if [ ! -f current_tf2_buildid ]; then
         echo "[$(date +'%D %H:%M:%S')] No current version saved, saving latest as current and doing nothing!"
         echo $LATEST > current_tf2_buildid
+
+        rm updater-active.lock
         exit 0
 
     elif [[ "$CURRENT" -ne "$LATEST" ]]; then
@@ -57,12 +66,15 @@ main() {
         done
 
         echo $LATEST > current_tf2_buildid
+        
+        rm updater-active.lock
         exit 0
 
     else
         echo "[$(date +'%D %H:%M:%S')] Current is latest, nothing to do"
-        exit 0
 
+        rm updater-active.lock
+        exit 0
     fi
 }
 

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -25,8 +25,8 @@
     dest: /home/tf2server/docker-compose_{{ network_shortname }}.yml
     mode: 0700
 
-- name: docker-compose up -d
-  shell: docker-compose up -d -f /home/tf2server/docker-compose_{{ network_shortname }}.yml
+- name: docker compose up -d
+  shell: docker compose -f /home/tf2server/docker-compose_{{ network_shortname }}.yml up -d
 
 - name: Install cronjob
   ansible.builtin.cron:

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -42,6 +42,6 @@
   ansible.builtin.cron:
     name: "ansible-tf2network: autoupdater"
     weekday: "*"
-    minute: "0"
+    minute: "*/10"
     hour: "*"
     job: "/home/tf2server/updater.sh >> /home/tf2server/updater.log"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -19,42 +19,14 @@
   delegate_to: localhost
   timeout: 10
 
-- name: Start ssh tunnel
-  community.docker.docker_container:
-    name: "ssh-{{ network_shortname }}"
-    image: "kroniak/ssh-client"
-    state: started
-    restart: true
-    restart_policy: "always"
-    volumes:
-      - /home/tf2server/.ssh/sbpp_key_{{ network_shortname }}:/root/id_rsa
-    networks:
-      - name: net-{{ network_shortname }}
-    command: ssh -4NTCp {{ sbpp_host_ssh_port }} -i /root/id_rsa -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -L 0.0.0.0:3306:db:3306 sbpp_user@{{ sbpp_host }}
+- name: Generate docker-compose
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: /home/tf2server/docker-compose_{{ network_shortname }}.yml
+    mode: 0700
 
-- name: Start SRCDS
-  community.docker.docker_container:
-    name: "srcds-{{network_shortname}}-{{ item.name }}"
-    image: "srcds-{{network_shortname}}-{{ item.name }}:latest"
-    state: started
-    restart: true
-    restart_policy: "unless-stopped"
-    cpuset_cpus: "{{ loop0 }}"
-    networks:
-      - name: net-{{ network_shortname }}
-    ports:
-      - "{{ item.port }}:{{ item.port }}"
-      - "{{ item.port }}:{{ item.port }}/udp"
-      - "{{ item.port + 5 }}:{{ item.port + 5 }}/udp"
-  loop: "{{ targets.instances }}"
-  loop_control:
-    index_var: loop0
-
-- name: Generate cronjob
-  set_fact:
-    cron: |
-      docker restart {% for item in instances %}
-      srcds-{{ item.name }} {% endfor %}
+- name: docker-compose up -d
+  shell: docker-compose up -d -f /home/tf2server/docker-compose_{{ network_shortname }}.yml
 
 - name: Install cronjob
   ansible.builtin.cron:
@@ -62,5 +34,5 @@
     weekday: "*"
     minute: "0"
     hour: "{{ daily_restart_hour_utc }}"
-    job: "{{ cron }}"
+    job: "docker-compose restart -f /home/tf2server/docker-compose_{{ network_shortname }}.yml"
   when: ansible_distribution == 'Ubuntu'

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -24,11 +24,24 @@
 - name: docker compose up -d
   shell: docker compose -f /home/tf2server/docker-compose_{{ network_shortname }}.yml up -d
 
-- name: Install cronjob
+- name: Install restart cronjob
   ansible.builtin.cron:
     name: "srcds-restart-{{ network_shortname }}"
     weekday: "*"
     minute: "0"
     hour: "{{ daily_restart_hour_utc }}"
     job: "docker-compose restart -f /home/tf2server/docker-compose_{{ network_shortname }}.yml"
-  when: ansible_distribution == 'Ubuntu'
+
+- name: Copy updater script
+  copy:
+    src: updater.sh
+    dest: /home/tf2server/updater.sh
+    mode: 0744
+
+- name: Install autoupdate cronjob
+  ansible.builtin.cron:
+    name: "ansible-tf2network: autoupdater"
+    weekday: "*"
+    minute: "0"
+    hour: "*"
+    job: "/home/tf2server/updater.sh >> /home/tf2server/updater.log"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -2,10 +2,6 @@
 - name: Perform setup
   ansible.builtin.include_tasks: setup.yml
 
-- name: Create network
-  docker_network:
-    name: net-{{ network_shortname }}
-
 - name: Announce update
   ignore_errors: true
   rcon:

--- a/roles/deploy/templates/docker-compose.yml.j2
+++ b/roles/deploy/templates/docker-compose.yml.j2
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+{% for item in targets.instances %}
+    {{ network_shortname }}-{{ item.name }}:
+        image: "srcds-{{ network_shortname }}-{{ item.name }}:latest"
+        restart: unless-stopped
+        cpuset: "{{ loop.index0 }}"
+        ports:
+            - "{{ item.port }}:{{ item.port }}"
+            - "{{ item.port }}:{{ item.port }}/udp"
+            - "{{ item.port + 5 }}:{{ item.port + 5 }}/udp"
+
+{% endfor %}
+
+    {{ network_shortname }}-ssh:
+        image: kroniak/ssh-client
+        restart: always
+        volumes:
+            - /home/tf2server/.ssh/sbpp_key_{{ network_shortname }}:/root/id_rsa
+        command: ssh -4NTCp {{ sbpp_host_ssh_port }} -i /root/id_rsa -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -L 0.0.0.0:3306:db:3306 sbpp_user@{{ sbpp_host }}

--- a/roles/deploy/templates/docker-compose.yml.j2
+++ b/roles/deploy/templates/docker-compose.yml.j2
@@ -10,6 +10,8 @@ services:
             - "{{ item.port }}:{{ item.port }}"
             - "{{ item.port }}:{{ item.port }}/udp"
             - "{{ item.port + 5 }}:{{ item.port + 5 }}/udp"
+        networks:
+            - net-{{ network_shortname }}
 
 {% endfor %}
     {{ network_shortname }}-ssh:
@@ -18,3 +20,8 @@ services:
         volumes:
             - /home/tf2server/.ssh/sbpp_key_{{ network_shortname }}:/root/id_rsa
         command: ssh -4NTCp {{ sbpp_host_ssh_port }} -i /root/id_rsa -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ExitOnForwardFailure=yes -L 0.0.0.0:3306:db:3306 sbpp_user@{{ sbpp_host }}
+        networks:
+            - net-{{ network_shortname }}
+
+networks:
+    net-{{ network_shortname }}:

--- a/roles/deploy/templates/docker-compose.yml.j2
+++ b/roles/deploy/templates/docker-compose.yml.j2
@@ -12,7 +12,6 @@ services:
             - "{{ item.port + 5 }}:{{ item.port + 5 }}/udp"
 
 {% endfor %}
-
     {{ network_shortname }}-ssh:
         image: kroniak/ssh-client
         restart: always

--- a/roles/srcds/templates/databases.cfg.j2
+++ b/roles/srcds/templates/databases.cfg.j2
@@ -24,7 +24,7 @@
         "sourcebans"
         {
                 "driver"                        "default"
-                "host"                          "ssh-{{ network_shortname }}"
+                "host"                          "{{ network_shortname }}-ssh"
                 "database"                      "sourcebans"
                 "user"                          "sourcebans"
                 "pass"                          "{{ sbpp_user_password }}"


### PR DESCRIPTION
adds a primitive autoupdate script. deploying with the new setup and an update dry run (via faking a different buildid in `current_tf2_buildid`) appears to complete successfully.

will need to wait for an actual TF2 update to confirm whether or not this is successful but for now this is promising